### PR TITLE
Cleanup: rm useless dependencies (nose2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,10 @@ jobs:
           cache: "pip"
 
       - name: Install pgserviceparser with test dependencies
-        run: pip install -e .[test]
+        run: pip install -e .
 
       - name: Run Python tests
         env:
             PGSERVICEPARSER_SRC_DIR: ${{ github.workspace }}
-        run: nose2 -v
+        run: |
+          python -m unittest test.test_lib

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ Optionally you can pass a config file path. Otherwise it gets it by `conf_path`.
 ### Test
 
 ```sh
-pip install -e .[test]
-nose2 -v
+pip install -e .
+export PGSERVICEPARSER_SRC_DIR=$pwd
+python -m unittest test.test_lib
 ```
 
 ### Git hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,6 @@ docs = [
     "mkdocs-material~=9.5.17",
     "fancyboxmd~=1.1"
 ]
-test = [
-  "nose2~=0.15",
-]
 
 [project.urls]
 homepage = "https://opengisch.github.io/pgserviceparser/"

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -1,4 +1,17 @@
-#! /usr/bin/env python
+#! python3
+
+"""Library unit tests.
+
+Usage from the repo root folder:
+
+    python -m unittest test.test_lib
+
+For a specific test:
+
+    python -m unittest test.test_lib.TestLib.test_remove_service
+
+"""
+
 import os
 import shutil
 import unittest
@@ -88,3 +101,7 @@ class TestLib(unittest.TestCase):
             -1,
             "Whitespaces between delimiters were found, but should not be present",
         )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> [!NOTE]
> This PR is a follow up of https://github.com/opengisch/pgserviceparser/pull/28

nose2 is useless here since unit tests are relying on standard lib only and are pretty straightforward.