### PR TITLE
Replace absolute import by a relative one

### DIFF
--- a/pgserviceparser/__init__.py
+++ b/pgserviceparser/__init__.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 # package
-from pgserviceparser.exceptions import ServiceFileNotFound, ServiceNotFound
+from .exceptions import ServiceFileNotFound, ServiceNotFound
 
 
 def conf_path() -> Path:


### PR DESCRIPTION

With the absolute import:

`from pgserviceparser.exceptions import ServiceFileNotFound, ServiceNotFound`


QGIS plugins using the `pgserviceparser` lib in this way:

`from my_plugin.libs import pgserviceparser`

are throwing this error at installation time (see https://github.com/opengisch/qgis-pg-service-parser-plugin/issues/47):

`ModuleNotFoundError: No module named 'pgserviceparser'`


However, if we replace the absolute import by a relative one:

`from .exceptions import ServiceFileNotFound, ServiceNotFound`


QGIS plugins will load without issues and the `pgserviceparser` lib will continue working as expected.

-----------------

@signedav, @3nids, @Guts, would this make sense for you?