### PR TITLE
Add write_service_to_text()

### DIFF
--- a/pgserviceparser/__init__.py
+++ b/pgserviceparser/__init__.py
@@ -1,5 +1,6 @@
 # standard library
 import configparser
+import io
 import platform
 from os import getenv
 from pathlib import Path
@@ -185,6 +186,27 @@ def write_service(
         config.write(configfile, space_around_delimiters=False)
 
     return dict(config[service_name])
+
+
+def write_service_to_text(service_name: str, settings: dict) -> str:
+    """Returns the complete service settings as a string.
+
+    Args:
+        service_name: service name
+        settings: settings dict defining the service config
+
+    Returns:
+        Service settings as a string
+    """
+    config = configparser.ConfigParser(interpolation=None)
+    config[service_name] = settings.copy()
+
+    config_stream = io.StringIO()
+    config.write(config_stream, space_around_delimiters=False)
+    res = config_stream.getvalue()
+    config_stream.close()
+
+    return res.strip()
 
 
 def service_names(conf_file_path: Optional[Path] = None) -> list[str]:

--- a/test/data/service_base.txt
+++ b/test/data/service_base.txt
@@ -18,3 +18,11 @@ dbname=db_3
 port=3333
 user=user_3
 password=pwd_3
+
+[service_4]
+host=my-project-db-65b82f87-f737-4d69-8cf4-1dd7cd8.withoutclouds.com
+dbname=db_4 # My comment
+port=4444
+user=user_4
+password=pwd_%4 # Test for issue #46
+sslkey=/home/s.key

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -4,10 +4,12 @@
 
 Usage from the repo root folder:
 
+    export PGSERVICEPARSER_SRC_DIR=$pwd
     python -m unittest test.test_lib
 
 For a specific test:
 
+    export PGSERVICEPARSER_SRC_DIR=$pwd
     python -m unittest test.test_lib.TestLib.test_remove_service
 
 """
@@ -25,6 +27,7 @@ from pgserviceparser import (
     service_names,
     write_service,
     write_service_setting,
+    write_service_to_text,
 )
 from pgserviceparser.exceptions import ServiceFileNotFound, ServiceNotFound
 
@@ -49,7 +52,7 @@ class TestLib(unittest.TestCase):
         self.assertRaises(ServiceFileNotFound, full_config, "non_existing_file")
 
     def test_service_names(self):
-        self.assertEqual(service_names(), ["service_1", "service_2", "service_3"])
+        self.assertEqual(service_names(), ["service_1", "service_2", "service_3", "service_4"])
 
     def test_service_config(self):
         self.assertRaises(ServiceNotFound, service_config, "non_existing_service")
@@ -108,6 +111,13 @@ class TestLib(unittest.TestCase):
         new_srv = write_service(service_name="service_4", settings=new_srv_settings, create_if_not_found=True)
         self.assertIsInstance(new_srv, dict)
         self.assertIn("service_4", service_names())
+
+    def test_write_service_to_text(self):
+        config_4 = service_config("service_4")
+        res = write_service_to_text("service_4", config_4)
+        expected = "[service_4]\nhost=my-project-db-65b82f87-f737-4d69-8cf4-1dd7cd8.withoutclouds.com\ndbname=db_4 # My comment\nport=4444\nuser=user_4\npassword=pwd_%4 # Test for issue #46\nsslkey=/home/s.key"
+
+        self.assertEqual(res, expected)
 
     def test_create_pgservice_file(self):
         # Create a new service file


### PR DESCRIPTION
As an alternative to writing the service settings to a file, we can now write them to a formatted string.

Unit tests added.